### PR TITLE
Replacing WebKit UI elements with QtQuick/QML

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ include(FeatureSummary)
 include(GenerateExportHeader)
 include(ECMInstallIcons)
 
-find_package(Qt5 REQUIRED COMPONENTS Core DBus Gui WebKitWidgets)
+find_package(Qt5 REQUIRED COMPONENTS Core DBus Gui Quick QuickWidgets)
 find_package(KF5 REQUIRED COMPONENTS Archive Config CoreAddons DocTools FileMetaData I18n IconThemes JobWidgets
                                      KCMUtils KIO Notifications NewStuff NotifyConfig Service Solid WidgetsAddons XmlGui)
 find_package(Iconv)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,7 @@ endif(ENABLE_PERMISSION_HELPER)
 add_subdirectory( icons )
 add_subdirectory( pics )
 add_subdirectory( services )
-
+add_subdirectory( qml )
 
 ########### next target ###############
 
@@ -67,6 +67,8 @@ qt5_generate_dbus_interface( ${CMAKE_CURRENT_SOURCE_DIR}/k3bdataprojectinterface
 qt5_add_dbus_adaptor( dbus_sources ${CMAKE_CURRENT_BINARY_DIR}/org.k3b.DataProject.xml k3bdataprojectinterface.h K3b::DataProjectInterface k3bdataprojectinterfaceadaptor K3bDataProjectInterfaceAdaptor )
 
 add_executable(k3b
+    stringtablemodel.cpp
+    stringgridmodel.cpp
     k3bwelcomewidget.cpp
     k3bapplication.cpp
     k3bdevicedelegate.cpp
@@ -221,6 +223,8 @@ target_include_directories(k3b PRIVATE
     projects/kostore
 )
 
+target_compile_definitions(k3b PRIVATE QML_INSTALL_DIR=${QML_INSTALL_DIR})
+
 target_link_libraries(k3b
     k3bdevice
     k3blib
@@ -236,7 +240,8 @@ target_link_libraries(k3b
     KF5::NotifyConfig
     KF5::Solid
     KF5::XmlGui
-    Qt5::WebKitWidgets
+    Qt5::Quick
+    Qt5::QuickWidgets
 )
 
 if(ICONV_FOUND)

--- a/src/k3bdiskinfoview.h
+++ b/src/k3bdiskinfoview.h
@@ -19,27 +19,39 @@
 
 #include "k3bmediacontentsview.h"
 
-class QWebView;
+class QQuickWidget;
+class QQmlContext;
+class QQmlApplicationEngine;
+class StringTableModel;
+class StringGridModel;
 
 namespace K3b {
-class DiskInfoView : public MediaContentsView
-{
-    Q_OBJECT
+    class DiskInfoView : public MediaContentsView
+    {
+        Q_OBJECT
 
-public:
-    DiskInfoView( QWidget* parent = 0 );
-    ~DiskInfoView();
+    public:
+        DiskInfoView( QWidget* parent = 0 );
+        ~DiskInfoView();
 
-private:
-    void reloadMedium();
-    void updateTitle();
-
-    QString createMediaInfoItems( const Medium& medium );
-    QString createIso9660InfoItems( const Iso9660SimplePrimaryDescriptor& iso );
-    QString createTrackItems( const Medium& medium );
-
-    QWebView* m_infoView;
-};
+    private:
+        void reloadMedium();
+        void updateTitle();
+        
+        void populateQmlContext(QQmlContext* context);
+        StringTableModel *populateMediumInfoTable(const K3b::Medium& medium);
+        StringTableModel *populateFilesystemInfoTable(const K3b::Iso9660SimplePrimaryDescriptor& iso);
+        StringGridModel *populateTracksTable(const K3b::Medium& medium);
+        
+        template<class T> void swapProperty(const char* key, T **itemPtr, T *newItem);
+        
+        StringTableModel *mediumTable;
+        StringTableModel *filesystemInfoTable;
+        StringGridModel *tracksGrid;
+        
+        QQmlApplicationEngine *m_qmlEngine;
+        QQuickWidget* m_infoView;
+    };
 }
 
 

--- a/src/qml/CMakeLists.txt
+++ b/src/qml/CMakeLists.txt
@@ -1,0 +1,1 @@
+install(FILES diskinfo.qml DESTINATION ${QML_INSTALL_DIR}/k3b)

--- a/src/qml/diskinfo.qml
+++ b/src/qml/diskinfo.qml
@@ -1,0 +1,172 @@
+import QtQuick 2.7
+import QtQuick.Controls 1.4
+import QtQuick.Layouts 1.1
+
+Item {
+    id: root
+    
+    property int reducedWidth: width - 25
+    
+    property string boxColor: "#475057"
+    property string boxTextColor: "white"
+    property int boxHeight: 30
+    property int boxTextSize: 12
+    
+    property int tableKeyCellWidth: 200
+    property int tableCellHeight: 27
+    
+    property int gridLayoutTextSize: 11
+    property real gridLayoutLeftPadding: 9.0
+    property color gridLayoutColor2: "#f5f5f5"
+    property color gridLayoutColor1: "#fcfcfc"
+    
+    Text {
+        visible: !isMediumPresent
+        x: 8
+        y: 4
+        color: "black"
+        leftPadding: gridLayoutLeftPadding
+        text: noMediumLabel
+        font.bold: true
+        horizontalAlignment: Text.AlignLeft
+        font.pointSize: boxTextSize
+    }
+
+    ScrollView {
+        visible: isMediumPresent
+        horizontalScrollBarPolicy: Qt.ScrollBarAlwaysOff
+        width: root.width
+        height: root.height
+
+        Column {
+            width: reducedWidth
+
+            Rectangle {
+                width: reducedWidth
+                height: boxHeight
+                color: boxColor
+
+                Text {
+                    x: 8
+                    y: 4
+                    color: boxTextColor
+                    text: mediumLabel
+                    font.bold: true
+                    horizontalAlignment: Text.AlignLeft
+                    font.pointSize: boxTextSize
+                }
+            }
+
+            TableView {                
+                headerVisible: false
+                selectionMode: SelectionMode.NoSelection
+                horizontalScrollBarPolicy: Qt.ScrollBarAlwaysOff
+                verticalScrollBarPolicy: Qt.ScrollBarAlwaysOff
+                width: reducedWidth
+                height: rowCount*tableCellHeight
+                frameVisible: false
+                TableViewColumn {
+                    role: "key"
+                    title: "Key"
+                    width: tableKeyCellWidth
+                }
+                TableViewColumn {
+                   role: "value"
+                    title: "Value"
+                    width: reducedWidth-tableKeyCellWidth
+                }
+                model: mediumTable
+            }
+
+            Rectangle {
+                visible: isIsoFilesystem
+                width: reducedWidth
+                height: boxHeight
+                color: boxColor
+
+                Text {
+                    x: 8
+                    y: 4
+                    color: boxTextColor
+                    text: isoLabel
+                    font.bold: true
+                    horizontalAlignment: Text.AlignLeft
+                    font.pointSize: boxTextSize
+                }
+            }
+
+            TableView {
+                visible: isIsoFilesystem
+                headerVisible: false
+                selectionMode: SelectionMode.NoSelection
+                horizontalScrollBarPolicy: Qt.ScrollBarAlwaysOff
+                verticalScrollBarPolicy: Qt.ScrollBarAlwaysOff
+                //Layout.fillWidth: true
+                width: reducedWidth
+                height: rowCount*tableCellHeight
+                frameVisible: false
+                TableViewColumn {
+                    role: "key"
+                    title: "Key"
+                    width: tableKeyCellWidth
+                }
+                TableViewColumn {
+                   role: "value"
+                   title: "Value"
+                   width: reducedWidth-tableKeyCellWidth
+                }
+                model: filesystemInfoTable
+            }
+
+            Rectangle {
+                visible: isTocNotEmpty
+                width: reducedWidth
+                height: boxHeight
+                color: boxColor
+
+                Text {
+                    x: 8
+                    y: 4
+                    color: boxTextColor
+                    text: tracksLabel
+                    font.bold: true
+                    horizontalAlignment: Text.AlignLeft
+                    font.pointSize: boxTextSize
+                }
+            }
+            
+            GridLayout {
+                id: gridLayout
+                width: reducedWidth
+                height: tableCellHeight*tracksGrid.getRowCount(gridLayout.columns)
+
+                columnSpacing: 0
+                rowSpacing: 0
+
+                columns: 7
+                rows: tracksGrid.getRowCount(columns)
+
+                property real columnWidth: width/columns
+
+                Repeater {
+                    model: tracksGrid
+
+                    delegate: Rectangle {
+                        id: rect
+                        Layout.columnSpan: colspan
+                        width: gridLayout.columnWidth*colspan
+                        height: tableCellHeight
+                        color: tracksGrid.isRowEvenNumbered(gridLayout.columns, index) ? gridLayoutColor1 : gridLayoutColor2
+                        Text {
+                            anchors.verticalCenter: rect.verticalCenter
+                            leftPadding: gridLayoutLeftPadding
+                            width: gridLayout.columnWidth*colspan
+                            text: itemText
+                            font.pointSize: gridLayoutTextSize
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/stringgridmodel.cpp
+++ b/src/stringgridmodel.cpp
@@ -1,0 +1,92 @@
+#include <QtCore/QVariant>
+#include <QtCore/QByteArray>
+#include <QtCore/QStringList>
+#include <QtCore/QString>
+#include <QtCore/QList>
+#include <QtCore/QModelIndex>
+
+#include "stringgridmodel.h"
+
+StringGridModel::StringGridModel()
+{}
+
+StringGridModel::~StringGridModel()
+{}
+
+StringGridModel& StringGridModel::operator<<(const GridItem& item)
+{
+    if(item.m_colspan>0)
+    {
+        GridItem gi(item);
+        list << gi;
+    }
+    return *this;
+}
+
+StringGridModel& StringGridModel::operator<<(const char* str)
+{
+    GridItem gi(QString(str), 1);
+    list << gi;
+    return *this;
+}
+
+StringGridModel& StringGridModel::operator<<(const QString& str)
+{
+    GridItem gi(str, 1);
+    list << gi;
+    return *this;
+}
+
+int StringGridModel::rowCount(const QModelIndex& parent) const
+{
+    return list.length();
+}
+
+int StringGridModel::getRow(int columnCount, int index)
+{
+
+    int cell=0;
+
+    for(int i=0; i<=index; i++)
+        cell+=list[i].m_colspan;
+
+    return (cell-1)/columnCount;
+}
+
+bool StringGridModel::isRowEvenNumbered(int columnCount, int index)
+{
+    return getRow(columnCount,index)%2==0;
+}
+
+int StringGridModel::getRowCount(int columnCount)
+{
+    int cell=0, index = list.length()-1;
+
+    for(int i=0; i<=index; i++)
+        cell+=list[i].m_colspan;
+
+    return 1+(cell-1)/columnCount;
+}
+
+QVariant StringGridModel::data(const QModelIndex& index, int role) const
+{
+    switch(role)
+    {
+        case 0:
+            return QVariant(list[index.row()].m_text);
+        case 1:
+            return QVariant::fromValue(list[index.row()].m_colspan);
+        default:
+            return QVariant(QString(""));
+    }
+}
+
+QHash<int, QByteArray> StringGridModel::roleNames() const
+{
+    QHash<int, QByteArray> roles;
+
+    roles[0]="itemText";
+    roles[1]="colspan";
+
+    return roles;
+}

--- a/src/stringgridmodel.h
+++ b/src/stringgridmodel.h
@@ -1,0 +1,57 @@
+#ifndef STRINGGRIDMODEL_H
+#define STRINGGRIDMODEL_H
+
+#include <QtCore/QObject>
+#include <QtCore/QString>
+#include <QtCore/QList>
+#include <QtCore/QModelIndex>
+
+class QVariant;
+class QByteArray;
+class QStringList;
+
+class GridItem : public QObject
+{
+    Q_OBJECT
+public:
+    explicit GridItem(QString text, int colspan = 1, QObject *parent = 0) : QObject(parent), m_text(text), m_colspan(colspan)
+    {}
+
+    GridItem(): GridItem("", 0)
+    {}
+
+    GridItem(const GridItem& other): GridItem(other.m_text, other.m_colspan)
+    {}
+
+    const QString m_text;
+    const int m_colspan;
+};
+Q_DECLARE_METATYPE( GridItem )
+
+
+class StringGridModel : public QAbstractListModel
+{
+    Q_OBJECT
+public:
+    StringGridModel();
+    ~StringGridModel();
+
+    StringGridModel& operator<<(const GridItem& item);
+    StringGridModel& operator<<(const char* str);
+    StringGridModel& operator<<(const QString& str);
+
+    int rowCount(const QModelIndex& parent = QModelIndex()) const;
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const;
+
+    Q_INVOKABLE int getRow(int columnCount, int index);
+    Q_INVOKABLE bool isRowEvenNumbered(int columnCount, int index);
+    Q_INVOKABLE int getRowCount(int columnCount);
+
+protected:
+    QHash<int, QByteArray> roleNames() const;
+
+private:
+    QList<GridItem> list;
+};
+
+#endif // STRINGGRIDMODEL_H

--- a/src/stringtablemodel.cpp
+++ b/src/stringtablemodel.cpp
@@ -1,0 +1,66 @@
+#include <QtCore/QVariant>
+#include <QtCore/QModelIndex>
+#include <QtCore/QVariant>
+#include <QtCore/QHash>
+#include <QtCore/QByteArray>
+#include <QtCore/QStringList>
+
+#include "stringtablemodel.h"
+
+StringTableModel::StringTableModel(QString emptyCell) : m_emptyCell(emptyCell)
+{}
+
+StringTableModel::~StringTableModel()
+{
+    for(int i=0; i<m_list.length(); i++)
+        delete m_list[i];
+}
+
+int StringTableModel::rowCount(const QModelIndex &parent) const
+{
+    return m_list.length();
+}
+
+int StringTableModel::columnCount(const QModelIndex &parent) const
+{
+    return m_roleList.length();
+}
+
+QVariant StringTableModel::data(const QModelIndex &index, int role) const
+{
+    if(m_list[index.row()]->length()<=role)
+    {
+        return QVariant(m_emptyCell);
+    }
+    
+    return QVariant(m_list[index.row()]->at(role));
+}
+
+QHash<int, QByteArray> StringTableModel::roleNames() const
+{
+    QHash<int, QByteArray> roles;
+
+    for(int i=0; i<m_roleList.length(); i++)
+        roles[i]=m_roleList[i].toUtf8().constData();
+
+    return roles;
+}
+
+QStringList& StringTableModel::newRow()
+{
+    QStringList* l = new QStringList();
+    
+    m_list.append(l);
+    
+    return *l;        
+}
+
+QStringList& StringTableModel::lastRow()
+{
+    return *m_list.constLast();
+}
+
+QStringList& StringTableModel::roles()
+{
+    return m_roleList;
+}

--- a/src/stringtablemodel.h
+++ b/src/stringtablemodel.h
@@ -1,0 +1,35 @@
+#ifndef STRINGTABLEMODEL_H
+#define STRINGTABLEMODEL_H
+
+#include <QtCore/QString>
+#include <QtCore/QAbstractTableModel>
+#include <QtCore/QHash>
+#include <QtCore/QList>
+
+class QModelIndex;
+class QVariant;
+class QByteArray;
+class QStringList;
+
+class StringTableModel : public QAbstractTableModel
+{
+public:
+    StringTableModel(QString emptyCell = QString(""));
+    ~StringTableModel();
+    
+    int rowCount(const QModelIndex &parent) const;
+    int columnCount(const QModelIndex &parent) const;
+    QVariant data(const QModelIndex &index, int role) const;
+    QHash<int, QByteArray> roleNames() const;
+
+    QStringList& newRow();
+    QStringList& lastRow();
+    QStringList& roles();
+
+private:
+    QString m_emptyCell;
+    QStringList m_roleList;
+    QList<QStringList*> m_list;
+};
+
+#endif // STRINGTABLEMODEL_H


### PR DESCRIPTION
Hi guys,

this is not really a pull request in earnest, more to get a conversation going. In order to learn about QtQuick, I've ported the HTML ui in k3bdiskinfoview.\* to QML. The resulting code doesn't depend on WebKit for building any more. The new disk info view should be more or less functionally complete (as least for run-off-the-mill data DVDs, I haven't tested anything else yet), but is not yet respecting the desktop's Plasma theme and shows some rendering weirdness/bug. 
Before I put more work into this to iron out these shortcomings, I'd like to ask if that is generally seen as something useful to do in terms of future development, or if you guys are more or less happy with things as they are.

Cheers,

Andreas
andreas.eckstein@gmx.net
